### PR TITLE
fix: remove ignore import path transformations on win32 platform

### DIFF
--- a/packages/classes/transformer-plugin/src/lib/utils.ts
+++ b/packages/classes/transformer-plugin/src/lib/utils.ts
@@ -110,10 +110,6 @@ export function replaceImportPath(
     if (!importPath) {
         return undefined;
     }
-
-    if (process.platform === 'win32') {
-      return typeReference.replace('import', 'require')
-    }
   
     importPath = importPath.slice(2, importPath.length - 1);
 


### PR DESCRIPTION
I would like to use this fork, but not sure if this repository will actively be maintained until nartc (if ever) returns. This fork works great for the NestJS v10 upgrade, but this particular issue is causing problems for a project I am working on. Essentially, the absolute paths are causing `Error: cannot find module {some absolute path}` messages on build, but if the import paths continue to be relative as they were before, it works without issue!