### PR TITLE
fix: add ts-patch support for Typescript v5

### DIFF
--- a/packages/classes/transformer-plugin/src/README.md
+++ b/packages/classes/transformer-plugin/src/README.md
@@ -199,9 +199,9 @@ export default {
 };
 ```
 
-### ttypescript
+### ts-patch
 
-ttypescript patches typescript in order to use transformers in tsconfig.json. See [ttypescript's README](https://github.com/cevek/ttypescript) for how to use this with module bundlers such as webpack or Rollup.
+ts-patch patches typescript in order to use transformers in tsconfig.json. See [ts-patch's README](https://github.com/nonara/ts-patch) for how to use this with module bundlers such as webpack or Rollup.
 
 ```
 {
@@ -210,6 +210,7 @@ ttypescript patches typescript in order to use transformers in tsconfig.json. Se
     "plugins": [
         {
             "transform": "automapper-classes/transformer-plugin",
+            "import": "tspBefore",
             "modelFileNameSuffix": [...]
         }
     ],

--- a/packages/classes/transformer-plugin/src/index.ts
+++ b/packages/classes/transformer-plugin/src/index.ts
@@ -52,5 +52,10 @@ export const before = (
     program: Program
 ) => automapperTransformerPlugin(program, options).before;
 
+export const tspBefore = (
+    program: Program,
+    options: AutomapperTransformerPluginOptions
+  ) => automapperTransformerPlugin(program, options).before;
+
 export * from './lib/options';
 export * from './lib/constants';


### PR DESCRIPTION
Original author ([nonara](https://github.com/nonara)) and pull request here: https://github.com/nartc/mapper/pull/556.

The signature for the `before` export was incorrect.